### PR TITLE
Add a Nunito font as substitute font on non macOS

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,7 +1,7 @@
 <!-- start custom head snippets -->
 
 <!-- Font Mr. Dafoe for Landing Page -->
-<link href="https://fonts.googleapis.com/css?family=Mr+Dafoe" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=Mr+Dafoe|Nunito+Sans:400,800&display=swap" rel="stylesheet">
 
 <!-- Mathjax to show equations from Latex code -->
 <script type="text/x-mathjax-config">

--- a/_sass/minimal-mistakes/_variables.scss
+++ b/_sass/minimal-mistakes/_variables.scss
@@ -14,8 +14,8 @@ $indent-var: 1.3em !default;
 
 /* system typefaces */
 $serif: Georgia, Times, serif !default;
-$sans-serif: Avenir Next, -apple-system, BlinkMacSystemFont, "Roboto", "Segoe UI",
-  "Helvetica Neue", "Lucida Grande", Arial, sans-serif !default;
+$sans-serif: "Avenir Next", "Nunito Sans", -apple-system, BlinkMacSystemFont, 
+  "Roboto", "Segoe UI", "Helvetica Neue", "Lucida Grande", Arial, sans-serif !default;
 $monospace: Monaco, Consolas, "Lucida Console", monospace !default;
 
 /* sans serif typefaces */


### PR DESCRIPTION
Non macOS systems doesn't have Avenir Next font, so I need some similar
font. I decided to choose Nunito.